### PR TITLE
refactor: replace runtime assertions with type guards (#134)

### DIFF
--- a/libs/causal_inference/causal_inference/core/optimization_mixin.py
+++ b/libs/causal_inference/causal_inference/core/optimization_mixin.py
@@ -73,8 +73,8 @@ class OptimizationMixin:
         ):
             return baseline_weights
 
-        # At this point, optimization_config is guaranteed to be non-None
-        assert self.optimization_config is not None  # Type narrowing for mypy
+        # Local variable for type narrowing (replaces assert statements)
+        config = self.optimization_config
 
         n_obs = len(baseline_weights)
 
@@ -88,13 +88,12 @@ class OptimizationMixin:
 
         # Set variance constraint from config if not provided
         if variance_constraint is None:
-            variance_constraint = self.optimization_config.variance_constraint
+            variance_constraint = config.variance_constraint
 
         # Define objective function
         def objective(w: NDArray[Any]) -> float:
             """Distance from baseline weights."""
-            assert self.optimization_config is not None  # Type narrowing for mypy
-            metric = self.optimization_config.distance_metric
+            metric = config.distance_metric
 
             if metric == "l2":
                 return float(np.sum((w - baseline_weights) ** 2))
@@ -118,8 +117,7 @@ class OptimizationMixin:
         constraints = []
 
         # Covariate balance constraint
-        assert self.optimization_config is not None  # Type narrowing for mypy
-        if self.optimization_config.balance_constraints:
+        if config.balance_constraints:
 
             def balance_constraint(w: NDArray[Any]) -> NDArray[Any]:
                 """Constraint: (1/n) X^T w = μ"""
@@ -142,17 +140,16 @@ class OptimizationMixin:
 
         # Optimize
         try:
-            assert self.optimization_config is not None  # Type narrowing for mypy
             result = minimize(
                 objective,
                 baseline_weights,
-                method=self.optimization_config.method,
+                method=config.method,
                 bounds=bounds,
                 constraints=constraints,
                 options={
-                    "maxiter": self.optimization_config.max_iterations,
-                    "ftol": self.optimization_config.convergence_tolerance,
-                    "disp": self.optimization_config.verbose,
+                    "maxiter": config.max_iterations,
+                    "ftol": config.convergence_tolerance,
+                    "disp": config.verbose,
                 },
             )
 
@@ -162,8 +159,7 @@ class OptimizationMixin:
             )
 
             # Store diagnostics (merge instead of overwriting)
-            assert self.optimization_config is not None  # Type narrowing for mypy
-            if self.optimization_config.store_diagnostics:
+            if config.store_diagnostics:
                 if not hasattr(self, "_optimization_diagnostics"):
                     self._optimization_diagnostics = {}
 
@@ -190,9 +186,9 @@ class OptimizationMixin:
 
             # Check constraint violations even on success
             if (
-                self.optimization_config.balance_constraints
+                config.balance_constraints
                 and constraint_violation
-                > self.optimization_config.balance_tolerance * 10
+                > config.balance_tolerance * 10
             ):
                 warnings.warn(
                     f"Optimization succeeded but severe constraint violation detected "

--- a/libs/causal_inference/tests/test_issue_134_type_guards.py
+++ b/libs/causal_inference/tests/test_issue_134_type_guards.py
@@ -1,0 +1,100 @@
+"""Tests for Issue #134: Replace runtime assertions with proper type guards."""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+
+from causal_inference.core.optimization_config import OptimizationConfig
+from causal_inference.core.optimization_mixin import OptimizationMixin
+
+
+class ConcreteOptimizer(OptimizationMixin):
+    """Concrete class using the mixin, for testing purposes."""
+
+    def __init__(
+        self,
+        optimization_config: OptimizationConfig | None = None,
+    ) -> None:
+        super().__init__(optimization_config=optimization_config)
+
+
+class TestNoAssertions:
+    """Verify that assert statements have been removed from optimize_weights_constrained."""
+
+    def test_optimization_mixin_no_assertions(self) -> None:
+        """No assert statements should remain in optimize_weights_constrained."""
+        source = inspect.getsource(OptimizationMixin.optimize_weights_constrained)
+        # Split into lines and check each non-comment line for assert
+        for line in source.splitlines():
+            stripped = line.strip()
+            # Skip comments
+            if stripped.startswith("#"):
+                continue
+            # No line should start with 'assert '
+            assert not stripped.startswith(
+                "assert "
+            ), f"Found assert statement in optimize_weights_constrained: {stripped}"
+
+
+class TestOptimizationStillWorks:
+    """Verify that optimization produces correct results after refactoring."""
+
+    def test_optimization_still_works(self) -> None:
+        """Optimization with a valid config should produce reasonable weights."""
+        config = OptimizationConfig(
+            optimize_weights=True,
+            method="SLSQP",
+            balance_constraints=True,
+            store_diagnostics=True,
+        )
+        optimizer = ConcreteOptimizer(optimization_config=config)
+
+        np.random.seed(42)
+        n = 100
+        baseline_weights = np.ones(n)
+        covariates = np.random.randn(n, 3)
+
+        result = optimizer.optimize_weights_constrained(
+            baseline_weights=baseline_weights,
+            covariates=covariates,
+        )
+
+        # Should return an array of the same length
+        assert len(result) == n
+        # Weights should be non-negative (due to bounds)
+        assert np.all(result >= -1e-10)
+        # Should be a numpy array
+        assert isinstance(result, np.ndarray)
+
+
+class TestEarlyReturnPaths:
+    """Verify early return behavior when config is None or optimization disabled."""
+
+    def test_optimization_none_config_returns_baseline(self) -> None:
+        """When optimization_config is None, baseline weights are returned."""
+        optimizer = ConcreteOptimizer(optimization_config=None)
+        baseline = np.array([1.0, 2.0, 3.0])
+        covariates = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+        result = optimizer.optimize_weights_constrained(
+            baseline_weights=baseline,
+            covariates=covariates,
+        )
+
+        np.testing.assert_array_equal(result, baseline)
+
+    def test_optimization_disabled_returns_baseline(self) -> None:
+        """When optimize_weights=False, baseline weights are returned."""
+        config = OptimizationConfig(optimize_weights=False)
+        optimizer = ConcreteOptimizer(optimization_config=config)
+        baseline = np.array([1.0, 2.0, 3.0])
+        covariates = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+        result = optimizer.optimize_weights_constrained(
+            baseline_weights=baseline,
+            covariates=covariates,
+        )
+
+        np.testing.assert_array_equal(result, baseline)


### PR DESCRIPTION
## Summary
- Replace 5 `assert` statements in OptimizationMixin with local variable pattern
- Safe under `python -O` (assertions stripped in production builds)
- Zero behavioral change, purely defensive refactor

## Test plan
- [ ] No assert statements remain in optimize_weights_constrained
- [ ] Optimization produces correct results with valid config
- [ ] Early return works when config is None or disabled
- [ ] `make ci` passes

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)